### PR TITLE
feat: Creator 회원가입 API 구현

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/liveklass/testa/domain/auth/controller/AuthController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping("/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/src/main/java/com/liveklass/testa/domain/creator/application/CreatorService.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/application/CreatorService.java
@@ -1,0 +1,35 @@
+package com.liveklass.testa.domain.creator.application;
+
+import com.liveklass.testa.domain.auth.domain.Account;
+import com.liveklass.testa.domain.auth.repository.AccountRepository;
+import com.liveklass.testa.domain.creator.controller.dto.CreatorSignUpRequest;
+import com.liveklass.testa.domain.creator.domain.Creator;
+import com.liveklass.testa.domain.creator.exception.DuplicateEmailException;
+import com.liveklass.testa.domain.creator.repository.CreatorRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CreatorService implements CreatorUseCase {
+
+    private final AccountRepository accountRepository;
+    private final CreatorRepository creatorRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void signUp(CreatorSignUpRequest request) {
+        if (accountRepository.existsByEmail(request.email())) {
+            throw new DuplicateEmailException();
+        }
+
+        Account account = Account.create(request.email(), passwordEncoder.encode(request.password()));
+        accountRepository.save(account);
+
+        Creator creator = Creator.create(account, request.name());
+        creatorRepository.save(creator);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/application/CreatorUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/application/CreatorUseCase.java
@@ -1,0 +1,8 @@
+package com.liveklass.testa.domain.creator.application;
+
+import com.liveklass.testa.domain.creator.controller.dto.CreatorSignUpRequest;
+
+public interface CreatorUseCase {
+
+    void signUp(CreatorSignUpRequest request);
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/controller/CreatorController.java
@@ -1,0 +1,26 @@
+package com.liveklass.testa.domain.creator.controller;
+
+import com.liveklass.testa.domain.creator.application.CreatorUseCase;
+import com.liveklass.testa.domain.creator.controller.dto.CreatorSignUpRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/creators")
+@RequiredArgsConstructor
+public class CreatorController {
+
+    private final CreatorUseCase creatorUseCase;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<Void> signUp(@Valid @RequestBody CreatorSignUpRequest request) {
+        creatorUseCase.signUp(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/controller/CreatorController.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/controller/CreatorController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/api/creators")
+@RequestMapping("/creators")
 @RequiredArgsConstructor
 public class CreatorController {
 

--- a/src/main/java/com/liveklass/testa/domain/creator/controller/dto/CreatorSignUpRequest.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/controller/dto/CreatorSignUpRequest.java
@@ -1,0 +1,11 @@
+package com.liveklass.testa.domain.creator.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record CreatorSignUpRequest(
+        @NotBlank @Email String email,
+        @NotBlank String password,
+        @NotBlank String name
+) {
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/domain/Creator.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/domain/Creator.java
@@ -1,0 +1,34 @@
+package com.liveklass.testa.domain.creator.domain;
+
+import com.liveklass.testa.domain.auth.domain.Account;
+import com.liveklass.testa.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "creators")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Creator extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "creator_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false, unique = true)
+    private Account account;
+
+    @Column(nullable = false)
+    private String name;
+
+    public static Creator create(Account account, String name) {
+        Creator creator = new Creator();
+        creator.account = account;
+        creator.name = name;
+        return creator;
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/exception/CreatorException.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/exception/CreatorException.java
@@ -1,0 +1,11 @@
+package com.liveklass.testa.domain.creator.exception;
+
+import com.liveklass.testa.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class CreatorException extends BusinessException {
+
+    public CreatorException(String errorCode, String message, HttpStatus httpStatus) {
+        super(errorCode, message, httpStatus);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/exception/CreatorExceptionHandler.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/exception/CreatorExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.liveklass.testa.domain.creator.exception;
+
+import com.liveklass.testa.global.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.liveklass.testa.domain.creator.controller")
+public class CreatorExceptionHandler {
+
+    @ExceptionHandler(CreatorException.class)
+    public ResponseEntity<ErrorResponse> handleCreatorException(CreatorException e) {
+        ErrorResponse response = ErrorResponse.of(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/exception/DuplicateEmailException.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/exception/DuplicateEmailException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.creator.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateEmailException extends CreatorException {
+
+    public DuplicateEmailException() {
+        super("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/creator/repository/CreatorRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/repository/CreatorRepository.java
@@ -1,0 +1,7 @@
+package com.liveklass.testa.domain.creator.repository;
+
+import com.liveklass.testa.domain.creator.domain.Creator;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreatorRepository extends JpaRepository<Creator, Long> {
+}

--- a/src/main/java/com/liveklass/testa/global/config/SecurityConfig.java
+++ b/src/main/java/com/liveklass/testa/global/config/SecurityConfig.java
@@ -25,9 +25,9 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/creators/sign-up").permitAll()
-                        .requestMatchers("/api/classmates/sign-up").permitAll()
+                        .requestMatchers("/auth/**").permitAll()
+                        .requestMatchers("/creators/sign-up").permitAll()
+                        .requestMatchers("/classmates/sign-up").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,3 +1,7 @@
+server:
+  servlet:
+    context-path: /api
+
 jwt:
   secret: local-dev-secret-key-must-be-at-least-32-bytes-long
   expiration-ms: 3600000


### PR DESCRIPTION
## Summary
- `POST /api/creators/sign-up` 엔드포인트 구현
- Account + Creator를 하나의 트랜잭션으로 생성
- 중복 이메일 검증 (409 Conflict)
- REALTEETH_TEST 패턴의 도메인 예외 처리 (CreatorException → CreatorExceptionHandler)
- `server.servlet.context-path: /api` 설정으로 공통 prefix를 한 곳에서 관리

## 구조
```
domain/creator/
├── application/
│   ├── CreatorUseCase.java      # 인터페이스
│   └── CreatorService.java      # 구현체
├── controller/
│   ├── CreatorController.java
│   └── dto/CreatorSignUpRequest.java
├── domain/
│   └── Creator.java             # Account 1:1 연관
├── exception/
│   ├── CreatorException.java
│   ├── CreatorExceptionHandler.java
│   └── DuplicateEmailException.java
└── repository/
    └── CreatorRepository.java
```

## 검증 결과
| 시나리오 | 결과 |
|---------|------|
| 정상 회원가입 | 201 Created |
| 가입 후 로그인 | 200 + JWT in Authorization header |
| 중복 이메일 | 409 + DUPLICATE_EMAIL |
| 빈 이름 | 400 + VALIDATION_ERROR |
| 잘못된 이메일 형식 | 400 + VALIDATION_ERROR |

## Test plan
- [x] `POST /api/creators/sign-up` 정상 회원가입 확인
- [x] 가입한 계정으로 `POST /api/auth/login` 로그인 확인
- [x] 중복 이메일로 가입 시도 → 409 응답 확인
- [x] 유효성 검증 실패 시 400 응답 확인

Closes #5
