### PR TITLE
feat: Classmate 회원가입 API 구현

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/classmate/application/ClassmateService.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/application/ClassmateService.java
@@ -1,0 +1,35 @@
+package com.liveklass.testa.domain.classmate.application;
+
+import com.liveklass.testa.domain.auth.domain.Account;
+import com.liveklass.testa.domain.auth.repository.AccountRepository;
+import com.liveklass.testa.domain.classmate.controller.dto.ClassmateSignUpRequest;
+import com.liveklass.testa.domain.classmate.domain.Classmate;
+import com.liveklass.testa.domain.classmate.exception.DuplicateEmailException;
+import com.liveklass.testa.domain.classmate.repository.ClassmateRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ClassmateService implements ClassmateUseCase {
+
+    private final AccountRepository accountRepository;
+    private final ClassmateRepository classmateRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Override
+    @Transactional
+    public void signUp(ClassmateSignUpRequest request) {
+        if (accountRepository.existsByEmail(request.email())) {
+            throw new DuplicateEmailException();
+        }
+
+        Account account = Account.create(request.email(), passwordEncoder.encode(request.password()));
+        accountRepository.save(account);
+
+        Classmate classmate = Classmate.create(account, request.name());
+        classmateRepository.save(classmate);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/application/ClassmateUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/application/ClassmateUseCase.java
@@ -1,0 +1,8 @@
+package com.liveklass.testa.domain.classmate.application;
+
+import com.liveklass.testa.domain.classmate.controller.dto.ClassmateSignUpRequest;
+
+public interface ClassmateUseCase {
+
+    void signUp(ClassmateSignUpRequest request);
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/controller/ClassmateController.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/controller/ClassmateController.java
@@ -1,0 +1,26 @@
+package com.liveklass.testa.domain.classmate.controller;
+
+import com.liveklass.testa.domain.classmate.application.ClassmateUseCase;
+import com.liveklass.testa.domain.classmate.controller.dto.ClassmateSignUpRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/classmates")
+@RequiredArgsConstructor
+public class ClassmateController {
+
+    private final ClassmateUseCase classmateUseCase;
+
+    @PostMapping("/sign-up")
+    public ResponseEntity<Void> signUp(@Valid @RequestBody ClassmateSignUpRequest request) {
+        classmateUseCase.signUp(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/controller/dto/ClassmateSignUpRequest.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/controller/dto/ClassmateSignUpRequest.java
@@ -1,0 +1,11 @@
+package com.liveklass.testa.domain.classmate.controller.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record ClassmateSignUpRequest(
+        @NotBlank @Email String email,
+        @NotBlank String password,
+        @NotBlank String name
+) {
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/domain/Classmate.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/domain/Classmate.java
@@ -1,0 +1,34 @@
+package com.liveklass.testa.domain.classmate.domain;
+
+import com.liveklass.testa.domain.auth.domain.Account;
+import com.liveklass.testa.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "classmates")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Classmate extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "classmate_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false, unique = true)
+    private Account account;
+
+    @Column(nullable = false)
+    private String name;
+
+    public static Classmate create(Account account, String name) {
+        Classmate classmate = new Classmate();
+        classmate.account = account;
+        classmate.name = name;
+        return classmate;
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/exception/ClassmateException.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/exception/ClassmateException.java
@@ -1,0 +1,11 @@
+package com.liveklass.testa.domain.classmate.exception;
+
+import com.liveklass.testa.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class ClassmateException extends BusinessException {
+
+    public ClassmateException(String errorCode, String message, HttpStatus httpStatus) {
+        super(errorCode, message, httpStatus);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/exception/ClassmateExceptionHandler.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/exception/ClassmateExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.liveklass.testa.domain.classmate.exception;
+
+import com.liveklass.testa.global.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.liveklass.testa.domain.classmate.controller")
+public class ClassmateExceptionHandler {
+
+    @ExceptionHandler(ClassmateException.class)
+    public ResponseEntity<ErrorResponse> handleClassmateException(ClassmateException e) {
+        ErrorResponse response = ErrorResponse.of(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/exception/DuplicateEmailException.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/exception/DuplicateEmailException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.classmate.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateEmailException extends ClassmateException {
+
+    public DuplicateEmailException() {
+        super("DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다.", HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/classmate/repository/ClassmateRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/repository/ClassmateRepository.java
@@ -1,0 +1,7 @@
+package com.liveklass.testa.domain.classmate.repository;
+
+import com.liveklass.testa.domain.classmate.domain.Classmate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ClassmateRepository extends JpaRepository<Classmate, Long> {
+}


### PR DESCRIPTION
## Summary
- `POST /api/classmates/sign-up` 엔드포인트 구현
- Account + Classmate를 하나의 트랜잭션으로 생성
- 중복 이메일 검증 (409 Conflict)
- REALTEETH_TEST 패턴의 도메인 예외 처리 (ClassmateException → ClassmateExceptionHandler)

## 구조
```
domain/classmate/
├── application/
│   ├── ClassmateUseCase.java      # 인터페이스
│   └── ClassmateService.java      # 구현체
├── controller/
│   ├── ClassmateController.java
│   └── dto/ClassmateSignUpRequest.java
├── domain/
│   └── Classmate.java             # Account 1:1 연관
├── exception/
│   ├── ClassmateException.java
│   ├── ClassmateExceptionHandler.java
│   └── DuplicateEmailException.java
└── repository/
    └── ClassmateRepository.java
```

## 검증 결과
| 시나리오 | 결과 |
|---------|------|
| 정상 회원가입 | 201 Created |
| 가입 후 로그인 | 200 + JWT in Authorization header |
| 중복 이메일 | 409 + DUPLICATE_EMAIL |
| 빈 이름 | 400 + VALIDATION_ERROR |
| 잘못된 이메일 형식 | 400 + VALIDATION_ERROR |

## Test plan
- [x] `POST /api/classmates/sign-up` 정상 회원가입 확인
- [x] 가입한 계정으로 `POST /api/auth/login` 로그인 확인
- [x] 중복 이메일로 가입 시도 → 409 응답 확인
- [x] 유효성 검증 실패 시 400 응답 확인

Closes #7
