### PR TITLE
feat: JWT에 역할(role) claim 추가

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/auth/application/AuthService.java
+++ b/src/main/java/com/liveklass/testa/domain/auth/application/AuthService.java
@@ -5,6 +5,8 @@ import com.liveklass.testa.domain.auth.domain.Account;
 import com.liveklass.testa.domain.auth.exception.AccountNotFoundException;
 import com.liveklass.testa.domain.auth.exception.InvalidPasswordException;
 import com.liveklass.testa.domain.auth.repository.AccountRepository;
+import com.liveklass.testa.domain.classmate.repository.ClassmateRepository;
+import com.liveklass.testa.domain.creator.repository.CreatorRepository;
 import com.liveklass.testa.infrastructure.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -16,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthService implements AuthUseCase {
 
     private final AccountRepository accountRepository;
+    private final CreatorRepository creatorRepository;
+    private final ClassmateRepository classmateRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
@@ -29,6 +33,17 @@ public class AuthService implements AuthUseCase {
             throw new InvalidPasswordException();
         }
 
-        return jwtTokenProvider.createToken(account.getId(), account.getEmail());
+        String role = resolveRole(account);
+        return jwtTokenProvider.createToken(account.getId(), account.getEmail(), role);
+    }
+
+    private String resolveRole(Account account) {
+        if (creatorRepository.existsByAccount(account)) {
+            return "CREATOR";
+        }
+        if (classmateRepository.existsByAccount(account)) {
+            return "CLASSMATE";
+        }
+        throw new AccountNotFoundException();
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/classmate/repository/ClassmateRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/repository/ClassmateRepository.java
@@ -1,7 +1,10 @@
 package com.liveklass.testa.domain.classmate.repository;
 
+import com.liveklass.testa.domain.auth.domain.Account;
 import com.liveklass.testa.domain.classmate.domain.Classmate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ClassmateRepository extends JpaRepository<Classmate, Long> {
+
+    boolean existsByAccount(Account account);
 }

--- a/src/main/java/com/liveklass/testa/domain/creator/repository/CreatorRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/creator/repository/CreatorRepository.java
@@ -1,7 +1,14 @@
 package com.liveklass.testa.domain.creator.repository;
 
+import com.liveklass.testa.domain.auth.domain.Account;
 import com.liveklass.testa.domain.creator.domain.Creator;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
+
+    boolean existsByAccount(Account account);
+
+    Optional<Creator> findByAccount(Account account);
 }

--- a/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtAuthenticationFilter.java
@@ -10,6 +10,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
 import java.io.IOException;
 import java.util.List;
 
@@ -27,8 +29,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Long accountId = jwtTokenProvider.getAccountId(token);
+            String role = jwtTokenProvider.getRole(token);
+            var authorities = List.of(new SimpleGrantedAuthority("ROLE_" + role));
             UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(accountId, null, List.of());
+                    new UsernamePasswordAuthenticationToken(accountId, null, authorities);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 

--- a/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtTokenProvider.java
@@ -24,13 +24,14 @@ public class JwtTokenProvider {
         this.expirationMs = expirationMs;
     }
 
-    public String createToken(Long accountId, String email) {
+    public String createToken(Long accountId, String email, String role) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + expirationMs);
 
         return Jwts.builder()
                 .subject(accountId.toString())
                 .claim("email", email)
+                .claim("role", role)
                 .issuedAt(now)
                 .expiration(expiry)
                 .signWith(secretKey)
@@ -47,8 +48,17 @@ public class JwtTokenProvider {
     }
 
     public Long getAccountId(String token) {
-        Claims claims = Jwts.parser().verifyWith(secretKey).build()
-                .parseSignedClaims(token).getPayload();
+        Claims claims = getClaims(token);
         return Long.valueOf(claims.getSubject());
+    }
+
+    public String getRole(String token) {
+        Claims claims = getClaims(token);
+        return claims.get("role", String.class);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(token).getPayload();
     }
 }


### PR DESCRIPTION
## Summary
- JWT 토큰에 `role` claim 추가 (CREATOR / CLASSMATE)
- 로그인 시 Creator/Classmate 테이블 조회로 역할 판별
- JwtAuthenticationFilter에서 `ROLE_CREATOR`, `ROLE_CLASSMATE`를 GrantedAuthority로 설정
- `hasRole('CREATOR')` 등 Spring Security 선언적 인가 사용 가능

## 변경 파일
- `JwtTokenProvider` — createToken에 role 파라미터 추가, getRole() 메서드 추가
- `JwtAuthenticationFilter` — role을 SimpleGrantedAuthority로 설정
- `AuthService` — resolveRole()로 Creator/Classmate 판별
- `CreatorRepository` — existsByAccount(), findByAccount() 추가
- `ClassmateRepository` — existsByAccount() 추가

## 검증 결과
| 시나리오 | 결과 |
|---------|------|
| Creator 로그인 → JWT payload | `"role": "CREATOR"` |
| Classmate 로그인 → JWT payload | `"role": "CLASSMATE"` |

## Test plan
- [x] Creator 회원가입 후 로그인 → JWT에 `role: CREATOR` 확인
- [x] Classmate 회원가입 후 로그인 → JWT에 `role: CLASSMATE` 확인

Closes #10
