### PR TITLE
feat: 강의(Class) 관리

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
@@ -5,6 +5,7 @@ import com.liveklass.testa.domain.auth.repository.AccountRepository;
 import com.liveklass.testa.domain.creator.domain.Creator;
 import com.liveklass.testa.domain.creator.repository.CreatorRepository;
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassDetailResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
 import com.liveklass.testa.domain.klass.domain.ClassStatus;
@@ -77,5 +78,17 @@ public class KlassService implements KlassUseCase {
         return classes.stream()
                 .map(KlassResponse::from)
                 .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public KlassDetailResponse findById(Long classId) {
+        Klass klass = klassRepository.findById(classId)
+                .orElseThrow(KlassNotFoundException::new);
+
+        // TODO: Enrollment 구현 시 실제 신청 인원으로 교체
+        int currentEnrollment = 0;
+
+        return KlassDetailResponse.of(klass, currentEnrollment);
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
@@ -5,8 +5,11 @@ import com.liveklass.testa.domain.auth.repository.AccountRepository;
 import com.liveklass.testa.domain.creator.domain.Creator;
 import com.liveklass.testa.domain.creator.repository.CreatorRepository;
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
 import com.liveklass.testa.domain.klass.domain.Klass;
 import com.liveklass.testa.domain.klass.exception.CreatorNotFoundException;
+import com.liveklass.testa.domain.klass.exception.KlassAccessDeniedException;
+import com.liveklass.testa.domain.klass.exception.KlassNotFoundException;
 import com.liveklass.testa.domain.klass.repository.KlassRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -38,5 +41,22 @@ public class KlassService implements KlassUseCase {
         );
 
         klassRepository.save(klass);
+    }
+
+    @Override
+    @Transactional
+    public void updateStatus(Long accountId, Long classId, KlassStatusUpdateRequest request) {
+        Account account = accountRepository.getReferenceById(accountId);
+        Creator creator = creatorRepository.findByAccount(account)
+                .orElseThrow(CreatorNotFoundException::new);
+
+        Klass klass = klassRepository.findById(classId)
+                .orElseThrow(KlassNotFoundException::new);
+
+        if (!klass.isOwnedBy(creator)) {
+            throw new KlassAccessDeniedException();
+        }
+
+        klass.changeStatus(request.status());
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
@@ -5,7 +5,9 @@ import com.liveklass.testa.domain.auth.repository.AccountRepository;
 import com.liveklass.testa.domain.creator.domain.Creator;
 import com.liveklass.testa.domain.creator.repository.CreatorRepository;
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
+import com.liveklass.testa.domain.klass.domain.ClassStatus;
 import com.liveklass.testa.domain.klass.domain.Klass;
 import com.liveklass.testa.domain.klass.exception.CreatorNotFoundException;
 import com.liveklass.testa.domain.klass.exception.KlassAccessDeniedException;
@@ -14,6 +16,8 @@ import com.liveklass.testa.domain.klass.repository.KlassRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -58,5 +62,20 @@ public class KlassService implements KlassUseCase {
         }
 
         klass.changeStatus(request.status());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<KlassResponse> findAll(ClassStatus status) {
+        List<Klass> classes;
+        if (status != null) {
+            classes = klassRepository.findByStatus(status);
+        } else {
+            classes = klassRepository.findAll();
+        }
+
+        return classes.stream()
+                .map(KlassResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
@@ -1,0 +1,42 @@
+package com.liveklass.testa.domain.klass.application;
+
+import com.liveklass.testa.domain.auth.domain.Account;
+import com.liveklass.testa.domain.auth.repository.AccountRepository;
+import com.liveklass.testa.domain.creator.domain.Creator;
+import com.liveklass.testa.domain.creator.repository.CreatorRepository;
+import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.domain.Klass;
+import com.liveklass.testa.domain.klass.exception.CreatorNotFoundException;
+import com.liveklass.testa.domain.klass.repository.KlassRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class KlassService implements KlassUseCase {
+
+    private final AccountRepository accountRepository;
+    private final CreatorRepository creatorRepository;
+    private final KlassRepository klassRepository;
+
+    @Override
+    @Transactional
+    public void create(Long accountId, KlassCreateRequest request) {
+        Account account = accountRepository.getReferenceById(accountId);
+        Creator creator = creatorRepository.findByAccount(account)
+                .orElseThrow(CreatorNotFoundException::new);
+
+        Klass klass = Klass.create(
+                creator,
+                request.title(),
+                request.description(),
+                request.price(),
+                request.maxCapacity(),
+                request.startDate(),
+                request.endDate()
+        );
+
+        klassRepository.save(klass);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
@@ -1,0 +1,8 @@
+package com.liveklass.testa.domain.klass.application;
+
+import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+
+public interface KlassUseCase {
+
+    void create(Long accountId, KlassCreateRequest request);
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
@@ -1,11 +1,17 @@
 package com.liveklass.testa.domain.klass.application;
 
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
+import com.liveklass.testa.domain.klass.domain.ClassStatus;
+
+import java.util.List;
 
 public interface KlassUseCase {
 
     void create(Long accountId, KlassCreateRequest request);
 
     void updateStatus(Long accountId, Long classId, KlassStatusUpdateRequest request);
+
+    List<KlassResponse> findAll(ClassStatus status);
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
@@ -1,8 +1,11 @@
 package com.liveklass.testa.domain.klass.application;
 
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
 
 public interface KlassUseCase {
 
     void create(Long accountId, KlassCreateRequest request);
+
+    void updateStatus(Long accountId, Long classId, KlassStatusUpdateRequest request);
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassUseCase.java
@@ -1,6 +1,7 @@
 package com.liveklass.testa.domain.klass.application;
 
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassDetailResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
 import com.liveklass.testa.domain.klass.domain.ClassStatus;
@@ -14,4 +15,6 @@ public interface KlassUseCase {
     void updateStatus(Long accountId, Long classId, KlassStatusUpdateRequest request);
 
     List<KlassResponse> findAll(ClassStatus status);
+
+    KlassDetailResponse findById(Long classId);
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
@@ -2,7 +2,9 @@ package com.liveklass.testa.domain.klass.controller;
 
 import com.liveklass.testa.domain.klass.application.KlassUseCase;
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
+import com.liveklass.testa.domain.klass.domain.ClassStatus;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -10,6 +12,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/classes")
@@ -33,5 +37,10 @@ public class KlassController {
                                              @Valid @RequestBody KlassStatusUpdateRequest request) {
         klassUseCase.updateStatus(accountId, classId, request);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<KlassResponse>> findAll(@RequestParam(required = false) ClassStatus status) {
+        return ResponseEntity.ok(klassUseCase.findAll(status));
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
@@ -1,0 +1,30 @@
+package com.liveklass.testa.domain.klass.controller;
+
+import com.liveklass.testa.domain.klass.application.KlassUseCase;
+import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/classes")
+@RequiredArgsConstructor
+public class KlassController {
+
+    private final KlassUseCase klassUseCase;
+
+    @PreAuthorize("hasRole('CREATOR')")
+    @PostMapping
+    public ResponseEntity<Void> create(@AuthenticationPrincipal Long accountId,
+                                       @Valid @RequestBody KlassCreateRequest request) {
+        klassUseCase.create(accountId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
@@ -2,6 +2,7 @@ package com.liveklass.testa.domain.klass.controller;
 
 import com.liveklass.testa.domain.klass.application.KlassUseCase;
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassDetailResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassResponse;
 import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
 import com.liveklass.testa.domain.klass.domain.ClassStatus;
@@ -42,5 +43,10 @@ public class KlassController {
     @GetMapping
     public ResponseEntity<List<KlassResponse>> findAll(@RequestParam(required = false) ClassStatus status) {
         return ResponseEntity.ok(klassUseCase.findAll(status));
+    }
+
+    @GetMapping("/{classId}")
+    public ResponseEntity<KlassDetailResponse> findById(@PathVariable Long classId) {
+        return ResponseEntity.ok(klassUseCase.findById(classId));
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/KlassController.java
@@ -2,16 +2,14 @@ package com.liveklass.testa.domain.klass.controller;
 
 import com.liveklass.testa.domain.klass.application.KlassUseCase;
 import com.liveklass.testa.domain.klass.controller.dto.KlassCreateRequest;
+import com.liveklass.testa.domain.klass.controller.dto.KlassStatusUpdateRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/classes")
@@ -26,5 +24,14 @@ public class KlassController {
                                        @Valid @RequestBody KlassCreateRequest request) {
         klassUseCase.create(accountId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PreAuthorize("hasRole('CREATOR')")
+    @PatchMapping("/{classId}/status")
+    public ResponseEntity<Void> updateStatus(@AuthenticationPrincipal Long accountId,
+                                             @PathVariable Long classId,
+                                             @Valid @RequestBody KlassStatusUpdateRequest request) {
+        klassUseCase.updateStatus(accountId, classId, request);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassCreateRequest.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassCreateRequest.java
@@ -1,0 +1,16 @@
+package com.liveklass.testa.domain.klass.controller.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record KlassCreateRequest(
+        @NotBlank String title,
+        @NotBlank String description,
+        @NotNull Integer price,
+        @NotNull Integer maxCapacity,
+        @NotNull LocalDate startDate,
+        @NotNull LocalDate endDate
+) {
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassDetailResponse.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassDetailResponse.java
@@ -1,0 +1,34 @@
+package com.liveklass.testa.domain.klass.controller.dto;
+
+import com.liveklass.testa.domain.klass.domain.ClassStatus;
+import com.liveklass.testa.domain.klass.domain.Klass;
+
+import java.time.LocalDate;
+
+public record KlassDetailResponse(
+        Long id,
+        String title,
+        String description,
+        int price,
+        int maxCapacity,
+        int currentEnrollment,
+        LocalDate startDate,
+        LocalDate endDate,
+        ClassStatus status,
+        String creatorName
+) {
+    public static KlassDetailResponse of(Klass klass, int currentEnrollment) {
+        return new KlassDetailResponse(
+                klass.getId(),
+                klass.getTitle(),
+                klass.getDescription(),
+                klass.getPrice(),
+                klass.getMaxCapacity(),
+                currentEnrollment,
+                klass.getStartDate(),
+                klass.getEndDate(),
+                klass.getStatus(),
+                klass.getCreator().getName()
+        );
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassResponse.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassResponse.java
@@ -1,0 +1,32 @@
+package com.liveklass.testa.domain.klass.controller.dto;
+
+import com.liveklass.testa.domain.klass.domain.ClassStatus;
+import com.liveklass.testa.domain.klass.domain.Klass;
+
+import java.time.LocalDate;
+
+public record KlassResponse(
+        Long id,
+        String title,
+        String description,
+        int price,
+        int maxCapacity,
+        LocalDate startDate,
+        LocalDate endDate,
+        ClassStatus status,
+        String creatorName
+) {
+    public static KlassResponse from(Klass klass) {
+        return new KlassResponse(
+                klass.getId(),
+                klass.getTitle(),
+                klass.getDescription(),
+                klass.getPrice(),
+                klass.getMaxCapacity(),
+                klass.getStartDate(),
+                klass.getEndDate(),
+                klass.getStatus(),
+                klass.getCreator().getName()
+        );
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassStatusUpdateRequest.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/controller/dto/KlassStatusUpdateRequest.java
@@ -1,0 +1,9 @@
+package com.liveklass.testa.domain.klass.controller.dto;
+
+import com.liveklass.testa.domain.klass.domain.ClassStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record KlassStatusUpdateRequest(
+        @NotNull ClassStatus status
+) {
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/domain/ClassStatus.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/domain/ClassStatus.java
@@ -1,0 +1,19 @@
+package com.liveklass.testa.domain.klass.domain;
+
+import java.util.Set;
+
+public enum ClassStatus {
+    DRAFT(Set.of("OPEN")),
+    OPEN(Set.of("CLOSED")),
+    CLOSED(Set.of());
+
+    private final Set<String> allowedTransitions;
+
+    ClassStatus(Set<String> allowedTransitions) {
+        this.allowedTransitions = allowedTransitions;
+    }
+
+    public boolean canTransitionTo(ClassStatus target) {
+        return allowedTransitions.contains(target.name());
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/domain/Klass.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/domain/Klass.java
@@ -2,6 +2,7 @@ package com.liveklass.testa.domain.klass.domain;
 
 import com.liveklass.testa.domain.creator.domain.Creator;
 import com.liveklass.testa.domain.klass.exception.InvalidKlassException;
+import com.liveklass.testa.domain.klass.exception.InvalidStatusTransitionException;
 import com.liveklass.testa.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -85,7 +86,7 @@ public class Klass extends BaseTimeEntity {
 
     public void changeStatus(ClassStatus target) {
         if (!this.status.canTransitionTo(target)) {
-            throw new IllegalStateException(
+            throw new InvalidStatusTransitionException(
                     this.status + "에서 " + target + "(으)로 변경할 수 없습니다.");
         }
         this.status = target;

--- a/src/main/java/com/liveklass/testa/domain/klass/domain/Klass.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/domain/Klass.java
@@ -1,0 +1,97 @@
+package com.liveklass.testa.domain.klass.domain;
+
+import com.liveklass.testa.domain.creator.domain.Creator;
+import com.liveklass.testa.domain.klass.exception.InvalidKlassException;
+import com.liveklass.testa.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "classes")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Klass extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "class_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "creator_id", nullable = false)
+    private Creator creator;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private int price;
+
+    @Column(nullable = false)
+    private int maxCapacity;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ClassStatus status;
+
+    public static Klass create(Creator creator, String title, String description,
+                               int price, int maxCapacity, LocalDate startDate, LocalDate endDate) {
+        validatePrice(price);
+        validateMaxCapacity(maxCapacity);
+        validateDateRange(startDate, endDate);
+
+        Klass klass = new Klass();
+        klass.creator = creator;
+        klass.title = title;
+        klass.description = description;
+        klass.price = price;
+        klass.maxCapacity = maxCapacity;
+        klass.startDate = startDate;
+        klass.endDate = endDate;
+        klass.status = ClassStatus.DRAFT;
+        return klass;
+    }
+
+    private static void validatePrice(int price) {
+        if (price < 0) {
+            throw new InvalidKlassException("가격은 0 이상이어야 합니다.");
+        }
+    }
+
+    private static void validateMaxCapacity(int maxCapacity) {
+        if (maxCapacity < 1) {
+            throw new InvalidKlassException("최대 정원은 1명 이상이어야 합니다.");
+        }
+    }
+
+    private static void validateDateRange(LocalDate startDate, LocalDate endDate) {
+        if (endDate.isBefore(startDate)) {
+            throw new InvalidKlassException("종료일은 시작일 이후여야 합니다.");
+        }
+    }
+
+    public void changeStatus(ClassStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new IllegalStateException(
+                    this.status + "에서 " + target + "(으)로 변경할 수 없습니다.");
+        }
+        this.status = target;
+    }
+
+    public boolean isOwnedBy(Creator creator) {
+        return this.creator.getId().equals(creator.getId());
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/exception/CreatorNotFoundException.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/exception/CreatorNotFoundException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.klass.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CreatorNotFoundException extends KlassException {
+
+    public CreatorNotFoundException() {
+        super("CREATOR_NOT_FOUND", "크리에이터 정보를 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/exception/InvalidKlassException.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/exception/InvalidKlassException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.klass.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidKlassException extends KlassException {
+
+    public InvalidKlassException(String message) {
+        super("INVALID_CLASS", message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/exception/InvalidStatusTransitionException.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/exception/InvalidStatusTransitionException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.klass.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidStatusTransitionException extends KlassException {
+
+    public InvalidStatusTransitionException(String message) {
+        super("INVALID_STATUS_TRANSITION", message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/exception/KlassAccessDeniedException.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/exception/KlassAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.klass.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class KlassAccessDeniedException extends KlassException {
+
+    public KlassAccessDeniedException() {
+        super("CLASS_ACCESS_DENIED", "해당 강의에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/exception/KlassException.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/exception/KlassException.java
@@ -1,0 +1,11 @@
+package com.liveklass.testa.domain.klass.exception;
+
+import com.liveklass.testa.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class KlassException extends BusinessException {
+
+    public KlassException(String errorCode, String message, HttpStatus httpStatus) {
+        super(errorCode, message, httpStatus);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/exception/KlassExceptionHandler.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/exception/KlassExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.liveklass.testa.domain.klass.exception;
+
+import com.liveklass.testa.global.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.liveklass.testa.domain.klass.controller")
+public class KlassExceptionHandler {
+
+    @ExceptionHandler(KlassException.class)
+    public ResponseEntity<ErrorResponse> handleKlassException(KlassException e) {
+        ErrorResponse response = ErrorResponse.of(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/exception/KlassNotFoundException.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/exception/KlassNotFoundException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.klass.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class KlassNotFoundException extends KlassException {
+
+    public KlassNotFoundException() {
+        super("CLASS_NOT_FOUND", "강의를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
@@ -1,0 +1,7 @@
+package com.liveklass.testa.domain.klass.repository;
+
+import com.liveklass.testa.domain.klass.domain.Klass;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface KlassRepository extends JpaRepository<Klass, Long> {
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
@@ -1,7 +1,12 @@
 package com.liveklass.testa.domain.klass.repository;
 
+import com.liveklass.testa.domain.klass.domain.ClassStatus;
 import com.liveklass.testa.domain.klass.domain.Klass;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface KlassRepository extends JpaRepository<Klass, Long> {
+
+    List<Klass> findByStatus(ClassStatus status);
 }

--- a/src/main/java/com/liveklass/testa/global/config/SecurityConfig.java
+++ b/src/main/java/com/liveklass/testa/global/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import com.liveklass.testa.infrastructure.jwt.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -14,6 +16,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -28,6 +31,7 @@ public class SecurityConfig {
                         .requestMatchers("/auth/**").permitAll()
                         .requestMatchers("/creators/sign-up").permitAll()
                         .requestMatchers("/classmates/sign-up").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/classes", "/classes/*").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/liveklass/testa/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/liveklass/testa/global/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.liveklass.testa.global.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -26,6 +27,12 @@ public class GlobalExceptionHandler {
                 .orElse("Validation failed");
         ErrorResponse response = ErrorResponse.of("VALIDATION_ERROR", message);
         return ResponseEntity.badRequest().body(response);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+        ErrorResponse response = ErrorResponse.of("ACCESS_DENIED", "접근 권한이 없습니다.");
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)


### PR DESCRIPTION
## Summary
강의(Class) 도메인의 전체 CRUD를 구현한다.

### 커밋별 기능
| 커밋 | 이슈 | 설명 |
|------|------|------|
| Class 엔티티 정의 | #11 | Klass 엔티티, ClassStatus enum, KlassRepository |
| 강의 등록 API | #12 | `POST /classes` (Creator만 가능, DRAFT 상태로 생성) |
| 강의 상태 변경 API | #13 | `PATCH /classes/{id}/status` (DRAFT→OPEN→CLOSED, 소유자 검증) |
| 강의 목록 조회 API | #14 | `GET /classes` (상태 필터, 인증 불필요) |
| 강의 상세 조회 API | #15 | `GET /classes/{id}` (현재 신청 인원 포함, 인증 불필요) |

### Security 인가 설정
- `POST /classes` → `CREATOR` 역할 필수
- `PATCH /classes/*/status` → `CREATOR` 역할 필수
- `GET /classes`, `GET /classes/*` → 인증 불필요 (permitAll)

## 검증 결과
| 시나리오 | 결과 |
|---------|------|
| Creator 강의 등록 | 201 Created (DRAFT) |
| Classmate 강의 등록 시도 | 403 Forbidden |
| DRAFT → OPEN | 200 |
| OPEN → CLOSED | 200 |
| CLOSED → OPEN (불가) | 400 INVALID_STATUS_TRANSITION |
| 다른 Creator가 상태 변경 시도 | 403 CLASS_ACCESS_DENIED |
| 존재하지 않는 강의 | 404 CLASS_NOT_FOUND |
| 전체 목록 조회 (인증 없이) | 200 |
| 상태 필터 조회 | 200 (필터 정상) |
| 상세 조회 (인증 없이) | 200 (currentEnrollment 포함) |

## Test plan
- [x] Creator 강의 등록 → 201, DRAFT 상태
- [x] Classmate 강의 등록 시도 → 403
- [x] DRAFT → OPEN → CLOSED 정상 전이
- [x] 잘못된 상태 전이 → 400
- [x] 다른 Creator 상태 변경 → 403
- [x] 존재하지 않는 강의 → 404
- [x] 목록 조회 (전체 + 상태 필터) 정상
- [x] 상세 조회 (currentEnrollment 포함) 정상

Closes #9, #11, #12, #13, #14, #15
