### PR TITLE
feat: 수강 신청(Enrollment) 관리

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/classmate/repository/ClassmateRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/classmate/repository/ClassmateRepository.java
@@ -4,7 +4,11 @@ import com.liveklass.testa.domain.auth.domain.Account;
 import com.liveklass.testa.domain.classmate.domain.Classmate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ClassmateRepository extends JpaRepository<Classmate, Long> {
 
     boolean existsByAccount(Account account);
+
+    Optional<Classmate> findByAccount(Account account);
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -1,0 +1,56 @@
+package com.liveklass.testa.domain.enrollment.application;
+
+import com.liveklass.testa.domain.auth.domain.Account;
+import com.liveklass.testa.domain.auth.repository.AccountRepository;
+import com.liveklass.testa.domain.classmate.domain.Classmate;
+import com.liveklass.testa.domain.classmate.repository.ClassmateRepository;
+import com.liveklass.testa.domain.enrollment.domain.Enrollment;
+import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
+import com.liveklass.testa.domain.enrollment.exception.ClassCapacityExceededException;
+import com.liveklass.testa.domain.enrollment.exception.ClassNotOpenException;
+import com.liveklass.testa.domain.enrollment.exception.ClassmateNotFoundException;
+import com.liveklass.testa.domain.enrollment.exception.DuplicateEnrollmentException;
+import com.liveklass.testa.domain.enrollment.repository.EnrollmentRepository;
+import com.liveklass.testa.domain.klass.domain.Klass;
+import com.liveklass.testa.domain.klass.exception.KlassNotFoundException;
+import com.liveklass.testa.domain.klass.repository.KlassRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class EnrollmentService implements EnrollmentUseCase {
+
+    private final AccountRepository accountRepository;
+    private final ClassmateRepository classmateRepository;
+    private final KlassRepository klassRepository;
+    private final EnrollmentRepository enrollmentRepository;
+
+    @Override
+    @Transactional
+    public void enroll(Long accountId, Long classId) {
+        Account account = accountRepository.getReferenceById(accountId);
+        Classmate classmate = classmateRepository.findByAccount(account)
+                .orElseThrow(ClassmateNotFoundException::new);
+
+        Klass klass = klassRepository.findByIdWithLock(classId)
+                .orElseThrow(KlassNotFoundException::new);
+
+        if (!klass.isOpen()) {
+            throw new ClassNotOpenException();
+        }
+
+        if (enrollmentRepository.existsByClassmateAndKlass(classmate, klass)) {
+            throw new DuplicateEnrollmentException();
+        }
+
+        int currentEnrollment = enrollmentRepository.countByKlassAndStatusNot(klass, EnrollmentStatus.CANCELLED);
+        if (currentEnrollment >= klass.getMaxCapacity()) {
+            throw new ClassCapacityExceededException();
+        }
+
+        Enrollment enrollment = Enrollment.create(classmate, klass);
+        enrollmentRepository.save(enrollment);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -10,6 +10,8 @@ import com.liveklass.testa.domain.enrollment.exception.ClassCapacityExceededExce
 import com.liveklass.testa.domain.enrollment.exception.ClassNotOpenException;
 import com.liveklass.testa.domain.enrollment.exception.ClassmateNotFoundException;
 import com.liveklass.testa.domain.enrollment.exception.DuplicateEnrollmentException;
+import com.liveklass.testa.domain.enrollment.exception.EnrollmentAccessDeniedException;
+import com.liveklass.testa.domain.enrollment.exception.EnrollmentNotFoundException;
 import com.liveklass.testa.domain.enrollment.repository.EnrollmentRepository;
 import com.liveklass.testa.domain.klass.domain.Klass;
 import com.liveklass.testa.domain.klass.exception.KlassNotFoundException;
@@ -52,5 +54,22 @@ public class EnrollmentService implements EnrollmentUseCase {
 
         Enrollment enrollment = Enrollment.create(classmate, klass);
         enrollmentRepository.save(enrollment);
+    }
+
+    @Override
+    @Transactional
+    public void confirm(Long accountId, Long enrollmentId) {
+        Account account = accountRepository.getReferenceById(accountId);
+        Classmate classmate = classmateRepository.findByAccount(account)
+                .orElseThrow(ClassmateNotFoundException::new);
+
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(EnrollmentNotFoundException::new);
+
+        if (!enrollment.isOwnedBy(classmate)) {
+            throw new EnrollmentAccessDeniedException();
+        }
+
+        enrollment.confirm();
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -72,4 +72,21 @@ public class EnrollmentService implements EnrollmentUseCase {
 
         enrollment.confirm();
     }
+
+    @Override
+    @Transactional
+    public void cancel(Long accountId, Long enrollmentId) {
+        Account account = accountRepository.getReferenceById(accountId);
+        Classmate classmate = classmateRepository.findByAccount(account)
+                .orElseThrow(ClassmateNotFoundException::new);
+
+        Enrollment enrollment = enrollmentRepository.findById(enrollmentId)
+                .orElseThrow(EnrollmentNotFoundException::new);
+
+        if (!enrollment.isOwnedBy(classmate)) {
+            throw new EnrollmentAccessDeniedException();
+        }
+
+        enrollment.cancel();
+    }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -4,6 +4,7 @@ import com.liveklass.testa.domain.auth.domain.Account;
 import com.liveklass.testa.domain.auth.repository.AccountRepository;
 import com.liveklass.testa.domain.classmate.domain.Classmate;
 import com.liveklass.testa.domain.classmate.repository.ClassmateRepository;
+import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
 import com.liveklass.testa.domain.enrollment.domain.Enrollment;
 import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
 import com.liveklass.testa.domain.enrollment.exception.ClassCapacityExceededException;
@@ -19,6 +20,8 @@ import com.liveklass.testa.domain.klass.repository.KlassRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -88,5 +91,17 @@ public class EnrollmentService implements EnrollmentUseCase {
         }
 
         enrollment.cancel();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<EnrollmentResponse> findMyEnrollments(Long accountId) {
+        Account account = accountRepository.getReferenceById(accountId);
+        Classmate classmate = classmateRepository.findByAccount(account)
+                .orElseThrow(ClassmateNotFoundException::new);
+
+        return enrollmentRepository.findByClassmate(classmate).stream()
+                .map(EnrollmentResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
@@ -5,4 +5,6 @@ public interface EnrollmentUseCase {
     void enroll(Long accountId, Long classId);
 
     void confirm(Long accountId, Long enrollmentId);
+
+    void cancel(Long accountId, Long enrollmentId);
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
@@ -1,0 +1,6 @@
+package com.liveklass.testa.domain.enrollment.application;
+
+public interface EnrollmentUseCase {
+
+    void enroll(Long accountId, Long classId);
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
@@ -1,5 +1,9 @@
 package com.liveklass.testa.domain.enrollment.application;
 
+import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
+
+import java.util.List;
+
 public interface EnrollmentUseCase {
 
     void enroll(Long accountId, Long classId);
@@ -7,4 +11,6 @@ public interface EnrollmentUseCase {
     void confirm(Long accountId, Long enrollmentId);
 
     void cancel(Long accountId, Long enrollmentId);
+
+    List<EnrollmentResponse> findMyEnrollments(Long accountId);
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
@@ -3,4 +3,6 @@ package com.liveklass.testa.domain.enrollment.application;
 public interface EnrollmentUseCase {
 
     void enroll(Long accountId, Long classId);
+
+    void confirm(Long accountId, Long enrollmentId);
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
@@ -1,15 +1,15 @@
 package com.liveklass.testa.domain.enrollment.controller;
 
 import com.liveklass.testa.domain.enrollment.application.EnrollmentUseCase;
+import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,5 +39,11 @@ public class EnrollmentController {
                                        @PathVariable Long enrollmentId) {
         enrollmentUseCase.cancel(accountId, enrollmentId);
         return ResponseEntity.ok().build();
+    }
+
+    @PreAuthorize("hasRole('CLASSMATE')")
+    @GetMapping("/enrollments/me")
+    public ResponseEntity<List<EnrollmentResponse>> findMyEnrollments(@AuthenticationPrincipal Long accountId) {
+        return ResponseEntity.ok(enrollmentUseCase.findMyEnrollments(accountId));
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
@@ -1,0 +1,26 @@
+package com.liveklass.testa.domain.enrollment.controller;
+
+import com.liveklass.testa.domain.enrollment.application.EnrollmentUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class EnrollmentController {
+
+    private final EnrollmentUseCase enrollmentUseCase;
+
+    @PreAuthorize("hasRole('CLASSMATE')")
+    @PostMapping("/classes/{classId}/enrollments")
+    public ResponseEntity<Void> enroll(@AuthenticationPrincipal Long accountId,
+                                       @PathVariable Long classId) {
+        enrollmentUseCase.enroll(accountId, classId);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
@@ -32,4 +32,12 @@ public class EnrollmentController {
         enrollmentUseCase.confirm(accountId, enrollmentId);
         return ResponseEntity.ok().build();
     }
+
+    @PreAuthorize("hasRole('CLASSMATE')")
+    @PatchMapping("/enrollments/{enrollmentId}/cancel")
+    public ResponseEntity<Void> cancel(@AuthenticationPrincipal Long accountId,
+                                       @PathVariable Long enrollmentId) {
+        enrollmentUseCase.cancel(accountId, enrollmentId);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,5 +23,13 @@ public class EnrollmentController {
                                        @PathVariable Long classId) {
         enrollmentUseCase.enroll(accountId, classId);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PreAuthorize("hasRole('CLASSMATE')")
+    @PatchMapping("/enrollments/{enrollmentId}/confirm")
+    public ResponseEntity<Void> confirm(@AuthenticationPrincipal Long accountId,
+                                        @PathVariable Long enrollmentId) {
+        enrollmentUseCase.confirm(accountId, enrollmentId);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/dto/EnrollmentResponse.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/dto/EnrollmentResponse.java
@@ -1,0 +1,28 @@
+package com.liveklass.testa.domain.enrollment.controller.dto;
+
+import com.liveklass.testa.domain.enrollment.domain.Enrollment;
+import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
+
+import java.time.LocalDateTime;
+
+public record EnrollmentResponse(
+        Long id,
+        Long classId,
+        String classTitle,
+        EnrollmentStatus status,
+        LocalDateTime enrolledAt,
+        LocalDateTime confirmedAt,
+        LocalDateTime cancelledAt
+) {
+    public static EnrollmentResponse from(Enrollment enrollment) {
+        return new EnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getKlass().getId(),
+                enrollment.getKlass().getTitle(),
+                enrollment.getStatus(),
+                enrollment.getEnrolledAt(),
+                enrollment.getConfirmedAt(),
+                enrollment.getCancelledAt()
+        );
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/domain/Enrollment.java
@@ -1,0 +1,75 @@
+package com.liveklass.testa.domain.enrollment.domain;
+
+import com.liveklass.testa.domain.classmate.domain.Classmate;
+import com.liveklass.testa.domain.enrollment.exception.InvalidEnrollmentStatusException;
+import com.liveklass.testa.domain.klass.domain.Klass;
+import com.liveklass.testa.global.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "enrollments")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Enrollment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "enrollment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "classmate_id", nullable = false)
+    private Classmate classmate;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "class_id", nullable = false)
+    private Klass klass;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EnrollmentStatus status;
+
+    @Column(nullable = false)
+    private LocalDateTime enrolledAt;
+
+    private LocalDateTime confirmedAt;
+
+    private LocalDateTime cancelledAt;
+
+    public static Enrollment create(Classmate classmate, Klass klass) {
+        Enrollment enrollment = new Enrollment();
+        enrollment.classmate = classmate;
+        enrollment.klass = klass;
+        enrollment.status = EnrollmentStatus.PENDING;
+        enrollment.enrolledAt = LocalDateTime.now();
+        return enrollment;
+    }
+
+    public void confirm() {
+        validateStatusTransition(EnrollmentStatus.CONFIRMED);
+        this.status = EnrollmentStatus.CONFIRMED;
+        this.confirmedAt = LocalDateTime.now();
+    }
+
+    public void cancel() {
+        validateStatusTransition(EnrollmentStatus.CANCELLED);
+        this.status = EnrollmentStatus.CANCELLED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    public boolean isOwnedBy(Classmate classmate) {
+        return this.classmate.getId().equals(classmate.getId());
+    }
+
+    private void validateStatusTransition(EnrollmentStatus target) {
+        if (!this.status.canTransitionTo(target)) {
+            throw new InvalidEnrollmentStatusException(
+                    this.status + "에서 " + target + "(으)로 변경할 수 없습니다.");
+        }
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/domain/EnrollmentStatus.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/domain/EnrollmentStatus.java
@@ -1,0 +1,19 @@
+package com.liveklass.testa.domain.enrollment.domain;
+
+import java.util.Set;
+
+public enum EnrollmentStatus {
+    PENDING(Set.of("CONFIRMED", "CANCELLED")),
+    CONFIRMED(Set.of("CANCELLED")),
+    CANCELLED(Set.of());
+
+    private final Set<String> allowedTransitions;
+
+    EnrollmentStatus(Set<String> allowedTransitions) {
+        this.allowedTransitions = allowedTransitions;
+    }
+
+    public boolean canTransitionTo(EnrollmentStatus target) {
+        return allowedTransitions.contains(target.name());
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/ClassCapacityExceededException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/ClassCapacityExceededException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ClassCapacityExceededException extends EnrollmentException {
+
+    public ClassCapacityExceededException() {
+        super("CLASS_CAPACITY_EXCEEDED", "수강 정원이 초과되었습니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/ClassNotOpenException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/ClassNotOpenException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ClassNotOpenException extends EnrollmentException {
+
+    public ClassNotOpenException() {
+        super("CLASS_NOT_OPEN", "모집 중인 강의에만 신청할 수 있습니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/ClassmateNotFoundException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/ClassmateNotFoundException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class ClassmateNotFoundException extends EnrollmentException {
+
+    public ClassmateNotFoundException() {
+        super("CLASSMATE_NOT_FOUND", "수강생 정보를 찾을 수 없습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/DuplicateEnrollmentException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/DuplicateEnrollmentException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateEnrollmentException extends EnrollmentException {
+
+    public DuplicateEnrollmentException() {
+        super("DUPLICATE_ENROLLMENT", "이미 신청한 강의입니다.", HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentAccessDeniedException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class EnrollmentAccessDeniedException extends EnrollmentException {
+
+    public EnrollmentAccessDeniedException() {
+        super("ENROLLMENT_ACCESS_DENIED", "해당 수강 신청에 대한 권한이 없습니다.", HttpStatus.FORBIDDEN);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentException.java
@@ -1,0 +1,11 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import com.liveklass.testa.global.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class EnrollmentException extends BusinessException {
+
+    public EnrollmentException(String errorCode, String message, HttpStatus httpStatus) {
+        super(errorCode, message, httpStatus);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentExceptionHandler.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentExceptionHandler.java
@@ -1,0 +1,16 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import com.liveklass.testa.global.exception.ErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice(basePackages = "com.liveklass.testa.domain.enrollment.controller")
+public class EnrollmentExceptionHandler {
+
+    @ExceptionHandler(EnrollmentException.class)
+    public ResponseEntity<ErrorResponse> handleEnrollmentException(EnrollmentException e) {
+        ErrorResponse response = ErrorResponse.of(e.getErrorCode(), e.getMessage());
+        return ResponseEntity.status(e.getHttpStatus()).body(response);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentNotFoundException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/EnrollmentNotFoundException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class EnrollmentNotFoundException extends EnrollmentException {
+
+    public EnrollmentNotFoundException() {
+        super("ENROLLMENT_NOT_FOUND", "수강 신청 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/InvalidEnrollmentStatusException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/InvalidEnrollmentStatusException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class InvalidEnrollmentStatusException extends EnrollmentException {
+
+    public InvalidEnrollmentStatusException(String message) {
+        super("INVALID_ENROLLMENT_STATUS", message, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
@@ -1,0 +1,19 @@
+package com.liveklass.testa.domain.enrollment.repository;
+
+import com.liveklass.testa.domain.classmate.domain.Classmate;
+import com.liveklass.testa.domain.enrollment.domain.Enrollment;
+import com.liveklass.testa.domain.klass.domain.Klass;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
+
+import java.util.List;
+
+public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
+
+    boolean existsByClassmateAndKlass(Classmate classmate, Klass klass);
+
+    List<Enrollment> findByClassmate(Classmate classmate);
+
+    int countByKlassAndStatusNot(Klass klass, EnrollmentStatus status);
+}

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
@@ -14,6 +14,8 @@ import com.liveklass.testa.domain.klass.exception.CreatorNotFoundException;
 import com.liveklass.testa.domain.klass.exception.KlassAccessDeniedException;
 import com.liveklass.testa.domain.klass.exception.KlassNotFoundException;
 import com.liveklass.testa.domain.klass.repository.KlassRepository;
+import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
+import com.liveklass.testa.domain.enrollment.repository.EnrollmentRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +29,7 @@ public class KlassService implements KlassUseCase {
     private final AccountRepository accountRepository;
     private final CreatorRepository creatorRepository;
     private final KlassRepository klassRepository;
+    private final EnrollmentRepository enrollmentRepository;
 
     @Override
     @Transactional
@@ -86,8 +89,7 @@ public class KlassService implements KlassUseCase {
         Klass klass = klassRepository.findById(classId)
                 .orElseThrow(KlassNotFoundException::new);
 
-        // TODO: Enrollment 구현 시 실제 신청 인원으로 교체
-        int currentEnrollment = 0;
+        int currentEnrollment = enrollmentRepository.countByKlassAndStatusNot(klass, EnrollmentStatus.CANCELLED);
 
         return KlassDetailResponse.of(klass, currentEnrollment);
     }

--- a/src/main/java/com/liveklass/testa/domain/klass/domain/Klass.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/domain/Klass.java
@@ -92,6 +92,10 @@ public class Klass extends BaseTimeEntity {
         this.status = target;
     }
 
+    public boolean isOpen() {
+        return this.status == ClassStatus.OPEN;
+    }
+
     public boolean isOwnedBy(Creator creator) {
         return this.creator.getId().equals(creator.getId());
     }

--- a/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
@@ -2,11 +2,20 @@ package com.liveklass.testa.domain.klass.repository;
 
 import com.liveklass.testa.domain.klass.domain.ClassStatus;
 import com.liveklass.testa.domain.klass.domain.Klass;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface KlassRepository extends JpaRepository<Klass, Long> {
 
     List<Klass> findByStatus(ClassStatus status);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT k FROM Klass k WHERE k.id = :id")
+    Optional<Klass> findByIdWithLock(@Param("id") Long id);
 }


### PR DESCRIPTION
## Summary
수강 신청(Enrollment) 도메인의 전체 CRUD를 구현한다.

Closes #18, #19, #20, #21, #22, #23

### 커밋별 기능
| 커밋 | 이슈 | 설명 |
|------|------|------|
| Enrollment 엔티티 정의 | #19 | Enrollment 엔티티, EnrollmentStatus enum, EnrollmentRepository |
| 수강 신청 API | #20 | `POST /classes/{classId}/enrollments` (CLASSMATE만, OPEN 강의만, 정원 제한, 중복 방지) |
| 결제 확정 API | #21 | `PATCH /enrollments/{id}/confirm` (PENDING → CONFIRMED) |
| 수강 취소 API | #22 | `PATCH /enrollments/{id}/cancel` (PENDING/CONFIRMED → CANCELLED) |
| 내 수강 신청 목록 조회 | #23 | `GET /enrollments/me` + 강의 상세의 currentEnrollment 실제 값 반영 |

### 동시성 제어
- 수강 신청 시 비관적 락(`PESSIMISTIC_WRITE`)으로 정원 초과 방지

### Security 인가 설정
- 모든 Enrollment API → `CLASSMATE` 역할 필수 (`@PreAuthorize`)

## 검증 결과
| # | 시나리오 | 결과 |
|---|---------|------|
| 1 | Classmate 수강 신청 | 201 ✓ |
| 2 | 중복 신청 | 409 ✓ |
| 3 | Creator 신청 시도 | 403 ✓ |
| 4 | DRAFT 강의에 신청 | 400 ✓ |
| 5 | 내 수강 신청 목록 조회 | 200 ✓ |
| 6 | 결제 확정 (PENDING → CONFIRMED) | 200 ✓ |
| 7 | 이미 CONFIRMED에서 재확정 | 400 ✓ |
| 8 | 수강 취소 (CONFIRMED → CANCELLED) | 200 ✓ |
| 9 | 이미 CANCELLED에서 재취소 | 400 ✓ |
| 10 | 강의 상세 currentEnrollment 반영 | 200 (0명) ✓ |
| 11 | Creator가 확정 시도 | 403 ✓ |
| 12 | 정원 1명 강의 첫 신청 | 201 ✓ |
| 13 | 정원 초과 신청 | 400 ✓ |
| 14 | 강의 상세 currentEnrollment = 1 | 200 ✓ |
