### PR TITLE
feat: 수강 취소 기간 제한

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -46,7 +46,7 @@ public class EnrollmentService implements EnrollmentUseCase {
             throw new ClassNotOpenException();
         }
 
-        if (enrollmentRepository.existsByClassmateAndKlass(classmate, klass)) {
+        if (enrollmentRepository.existsByClassmateAndKlassAndStatusNot(classmate, klass, EnrollmentStatus.CANCELLED)) {
             throw new DuplicateEnrollmentException();
         }
 

--- a/src/main/java/com/liveklass/testa/domain/enrollment/domain/Enrollment.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/domain/Enrollment.java
@@ -1,6 +1,7 @@
 package com.liveklass.testa.domain.enrollment.domain;
 
 import com.liveklass.testa.domain.classmate.domain.Classmate;
+import com.liveklass.testa.domain.enrollment.exception.CancellationPeriodExpiredException;
 import com.liveklass.testa.domain.enrollment.exception.InvalidEnrollmentStatusException;
 import com.liveklass.testa.domain.klass.domain.Klass;
 import com.liveklass.testa.global.entity.BaseTimeEntity;
@@ -10,6 +11,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 @Entity
 @Table(name = "enrollments")
@@ -56,10 +58,22 @@ public class Enrollment extends BaseTimeEntity {
         this.confirmedAt = LocalDateTime.now();
     }
 
+    private static final int CANCELLATION_PERIOD_DAYS = 7;
+
     public void cancel() {
         validateStatusTransition(EnrollmentStatus.CANCELLED);
+        validateCancellationPeriod();
         this.status = EnrollmentStatus.CANCELLED;
         this.cancelledAt = LocalDateTime.now();
+    }
+
+    private void validateCancellationPeriod() {
+        if (this.status == EnrollmentStatus.CONFIRMED && this.confirmedAt != null) {
+            long daysSinceConfirmed = ChronoUnit.DAYS.between(this.confirmedAt, LocalDateTime.now());
+            if (daysSinceConfirmed > CANCELLATION_PERIOD_DAYS) {
+                throw new CancellationPeriodExpiredException();
+            }
+        }
     }
 
     public boolean isOwnedBy(Classmate classmate) {

--- a/src/main/java/com/liveklass/testa/domain/enrollment/exception/CancellationPeriodExpiredException.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/exception/CancellationPeriodExpiredException.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.domain.enrollment.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class CancellationPeriodExpiredException extends EnrollmentException {
+
+    public CancellationPeriodExpiredException() {
+        super("CANCELLATION_PERIOD_EXPIRED", "취소 가능 기간(결제 확정 후 7일)이 지났습니다.", HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
-    boolean existsByClassmateAndKlass(Classmate classmate, Klass klass);
+    boolean existsByClassmateAndKlassAndStatusNot(Classmate classmate, Klass klass, EnrollmentStatus status);
 
     List<Enrollment> findByClassmate(Classmate classmate);
 


### PR DESCRIPTION
## Summary
CONFIRMED 상태의 수강 신청에 대해 결제 확정 후 7일 이내만 취소 가능하도록 제한한다.

Closes #25

### 변경 내용
- `Enrollment.cancel()`에 취소 기간 검증 추가 (CONFIRMED + 7일 초과 시 거부)
- PENDING 상태 취소는 기간 제한 없음
- 취소된 신청은 중복 체크에서 제외하여 재신청 허용 (기존 버그 수정)

## 검증 결과
| # | 시나리오 | 결과 |
|---|---------|------|
| 1 | PENDING 취소 (기간 제한 없음) | 200 ✓ |
| 2 | 취소 후 재신청 | 201 ✓ |
| 3 | CONFIRMED 7일 이내 취소 | 200 ✓ |
| 4 | CONFIRMED 7일 초과 취소 | 400 CANCELLATION_PERIOD_EXPIRED ✓ |
