### PR TITLE
feat: 강의별 수강생 목록 조회

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -4,7 +4,11 @@ import com.liveklass.testa.domain.auth.domain.Account;
 import com.liveklass.testa.domain.auth.repository.AccountRepository;
 import com.liveklass.testa.domain.classmate.domain.Classmate;
 import com.liveklass.testa.domain.classmate.repository.ClassmateRepository;
+import com.liveklass.testa.domain.enrollment.controller.dto.ClassEnrollmentResponse;
 import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
+import com.liveklass.testa.domain.creator.domain.Creator;
+import com.liveklass.testa.domain.creator.repository.CreatorRepository;
+import com.liveklass.testa.domain.klass.exception.KlassAccessDeniedException;
 import com.liveklass.testa.domain.enrollment.domain.Enrollment;
 import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
 import com.liveklass.testa.domain.enrollment.exception.ClassCapacityExceededException;
@@ -15,6 +19,7 @@ import com.liveklass.testa.domain.enrollment.exception.EnrollmentAccessDeniedExc
 import com.liveklass.testa.domain.enrollment.exception.EnrollmentNotFoundException;
 import com.liveklass.testa.domain.enrollment.repository.EnrollmentRepository;
 import com.liveklass.testa.domain.klass.domain.Klass;
+import com.liveklass.testa.domain.klass.exception.CreatorNotFoundException;
 import com.liveklass.testa.domain.klass.exception.KlassNotFoundException;
 import com.liveklass.testa.domain.klass.repository.KlassRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,6 +34,7 @@ public class EnrollmentService implements EnrollmentUseCase {
 
     private final AccountRepository accountRepository;
     private final ClassmateRepository classmateRepository;
+    private final CreatorRepository creatorRepository;
     private final KlassRepository klassRepository;
     private final EnrollmentRepository enrollmentRepository;
 
@@ -102,6 +108,25 @@ public class EnrollmentService implements EnrollmentUseCase {
 
         return enrollmentRepository.findByClassmate(classmate).stream()
                 .map(EnrollmentResponse::from)
+                .toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ClassEnrollmentResponse> findClassEnrollments(Long accountId, Long classId) {
+        Account account = accountRepository.getReferenceById(accountId);
+        Creator creator = creatorRepository.findByAccount(account)
+                .orElseThrow(CreatorNotFoundException::new);
+
+        Klass klass = klassRepository.findById(classId)
+                .orElseThrow(KlassNotFoundException::new);
+
+        if (!klass.isOwnedBy(creator)) {
+            throw new KlassAccessDeniedException();
+        }
+
+        return enrollmentRepository.findByKlassAndStatusNot(klass, EnrollmentStatus.CANCELLED).stream()
+                .map(ClassEnrollmentResponse::from)
                 .toList();
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
@@ -1,5 +1,6 @@
 package com.liveklass.testa.domain.enrollment.application;
 
+import com.liveklass.testa.domain.enrollment.controller.dto.ClassEnrollmentResponse;
 import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
 
 import java.util.List;
@@ -13,4 +14,6 @@ public interface EnrollmentUseCase {
     void cancel(Long accountId, Long enrollmentId);
 
     List<EnrollmentResponse> findMyEnrollments(Long accountId);
+
+    List<ClassEnrollmentResponse> findClassEnrollments(Long accountId, Long classId);
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
@@ -1,6 +1,7 @@
 package com.liveklass.testa.domain.enrollment.controller;
 
 import com.liveklass.testa.domain.enrollment.application.EnrollmentUseCase;
+import com.liveklass.testa.domain.enrollment.controller.dto.ClassEnrollmentResponse;
 import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -45,5 +46,13 @@ public class EnrollmentController {
     @GetMapping("/enrollments/me")
     public ResponseEntity<List<EnrollmentResponse>> findMyEnrollments(@AuthenticationPrincipal Long accountId) {
         return ResponseEntity.ok(enrollmentUseCase.findMyEnrollments(accountId));
+    }
+
+    @PreAuthorize("hasRole('CREATOR')")
+    @GetMapping("/classes/{classId}/enrollments")
+    public ResponseEntity<List<ClassEnrollmentResponse>> findClassEnrollments(
+            @AuthenticationPrincipal Long accountId,
+            @PathVariable Long classId) {
+        return ResponseEntity.ok(enrollmentUseCase.findClassEnrollments(accountId, classId));
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/dto/ClassEnrollmentResponse.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/dto/ClassEnrollmentResponse.java
@@ -1,0 +1,26 @@
+package com.liveklass.testa.domain.enrollment.controller.dto;
+
+import com.liveklass.testa.domain.enrollment.domain.Enrollment;
+import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
+
+import java.time.LocalDateTime;
+
+public record ClassEnrollmentResponse(
+        Long enrollmentId,
+        Long classmateId,
+        String classmateName,
+        EnrollmentStatus status,
+        LocalDateTime enrolledAt,
+        LocalDateTime confirmedAt
+) {
+    public static ClassEnrollmentResponse from(Enrollment enrollment) {
+        return new ClassEnrollmentResponse(
+                enrollment.getId(),
+                enrollment.getClassmate().getId(),
+                enrollment.getClassmate().getName(),
+                enrollment.getStatus(),
+                enrollment.getEnrolledAt(),
+                enrollment.getConfirmedAt()
+        );
+    }
+}

--- a/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
@@ -16,4 +16,6 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
     List<Enrollment> findByClassmate(Classmate classmate);
 
     int countByKlassAndStatusNot(Klass klass, EnrollmentStatus status);
+
+    List<Enrollment> findByKlassAndStatusNot(Klass klass, EnrollmentStatus status);
 }


### PR DESCRIPTION
## Summary
크리에이터가 본인 강의의 수강생 목록을 조회할 수 있는 API를 추가한다.

Closes #27

### 변경 내용
- `GET /classes/{classId}/enrollments` 엔드포인트 추가
- CREATOR 본인 강의만 조회 가능 (소유권 검증)
- CANCELLED 상태 제외, PENDING/CONFIRMED 신청만 반환
- `ClassEnrollmentResponse` DTO 추가

## 검증 결과
| # | 시나리오 | 결과 |
|---|---------|------|
| 1 | Creator 본인 강의 수강생 조회 | 200 (CONFIRMED + PENDING) ✓ |
| 2 | Classmate 조회 시도 | 403 ACCESS_DENIED ✓ |
| 3 | 다른 Creator 조회 시도 | 403 CLASS_ACCESS_DENIED ✓ |
| 4 | 취소 후 목록 (CANCELLED 제외) | 200 (PENDING만 남음) ✓ |
