### PR TITLE
feat: 수강 신청 내역 페이지네이션

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -23,10 +23,10 @@ import com.liveklass.testa.domain.klass.exception.CreatorNotFoundException;
 import com.liveklass.testa.domain.klass.exception.KlassNotFoundException;
 import com.liveklass.testa.domain.klass.repository.KlassRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -101,19 +101,18 @@ public class EnrollmentService implements EnrollmentUseCase {
 
     @Override
     @Transactional(readOnly = true)
-    public List<EnrollmentResponse> findMyEnrollments(Long accountId) {
+    public Page<EnrollmentResponse> findMyEnrollments(Long accountId, Pageable pageable) {
         Account account = accountRepository.getReferenceById(accountId);
         Classmate classmate = classmateRepository.findByAccount(account)
                 .orElseThrow(ClassmateNotFoundException::new);
 
-        return enrollmentRepository.findByClassmate(classmate).stream()
-                .map(EnrollmentResponse::from)
-                .toList();
+        return enrollmentRepository.findByClassmate(classmate, pageable)
+                .map(EnrollmentResponse::from);
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<ClassEnrollmentResponse> findClassEnrollments(Long accountId, Long classId) {
+    public Page<ClassEnrollmentResponse> findClassEnrollments(Long accountId, Long classId, Pageable pageable) {
         Account account = accountRepository.getReferenceById(accountId);
         Creator creator = creatorRepository.findByAccount(account)
                 .orElseThrow(CreatorNotFoundException::new);
@@ -125,8 +124,7 @@ public class EnrollmentService implements EnrollmentUseCase {
             throw new KlassAccessDeniedException();
         }
 
-        return enrollmentRepository.findByKlassAndStatusNot(klass, EnrollmentStatus.CANCELLED).stream()
-                .map(ClassEnrollmentResponse::from)
-                .toList();
+        return enrollmentRepository.findByKlassAndStatusNot(klass, EnrollmentStatus.CANCELLED, pageable)
+                .map(ClassEnrollmentResponse::from);
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentUseCase.java
@@ -2,8 +2,8 @@ package com.liveklass.testa.domain.enrollment.application;
 
 import com.liveklass.testa.domain.enrollment.controller.dto.ClassEnrollmentResponse;
 import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
-
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 public interface EnrollmentUseCase {
 
@@ -13,7 +13,7 @@ public interface EnrollmentUseCase {
 
     void cancel(Long accountId, Long enrollmentId);
 
-    List<EnrollmentResponse> findMyEnrollments(Long accountId);
+    Page<EnrollmentResponse> findMyEnrollments(Long accountId, Pageable pageable);
 
-    List<ClassEnrollmentResponse> findClassEnrollments(Long accountId, Long classId);
+    Page<ClassEnrollmentResponse> findClassEnrollments(Long accountId, Long classId, Pageable pageable);
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/controller/EnrollmentController.java
@@ -4,13 +4,14 @@ import com.liveklass.testa.domain.enrollment.application.EnrollmentUseCase;
 import com.liveklass.testa.domain.enrollment.controller.dto.ClassEnrollmentResponse;
 import com.liveklass.testa.domain.enrollment.controller.dto.EnrollmentResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -44,15 +45,18 @@ public class EnrollmentController {
 
     @PreAuthorize("hasRole('CLASSMATE')")
     @GetMapping("/enrollments/me")
-    public ResponseEntity<List<EnrollmentResponse>> findMyEnrollments(@AuthenticationPrincipal Long accountId) {
-        return ResponseEntity.ok(enrollmentUseCase.findMyEnrollments(accountId));
+    public ResponseEntity<Page<EnrollmentResponse>> findMyEnrollments(
+            @AuthenticationPrincipal Long accountId,
+            @PageableDefault(size = 20, sort = "enrolledAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(enrollmentUseCase.findMyEnrollments(accountId, pageable));
     }
 
     @PreAuthorize("hasRole('CREATOR')")
     @GetMapping("/classes/{classId}/enrollments")
-    public ResponseEntity<List<ClassEnrollmentResponse>> findClassEnrollments(
+    public ResponseEntity<Page<ClassEnrollmentResponse>> findClassEnrollments(
             @AuthenticationPrincipal Long accountId,
-            @PathVariable Long classId) {
-        return ResponseEntity.ok(enrollmentUseCase.findClassEnrollments(accountId, classId));
+            @PathVariable Long classId,
+            @PageableDefault(size = 20, sort = "enrolledAt", direction = org.springframework.data.domain.Sort.Direction.DESC) Pageable pageable) {
+        return ResponseEntity.ok(enrollmentUseCase.findClassEnrollments(accountId, classId, pageable));
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
@@ -3,19 +3,19 @@ package com.liveklass.testa.domain.enrollment.repository;
 import com.liveklass.testa.domain.classmate.domain.Classmate;
 import com.liveklass.testa.domain.enrollment.domain.Enrollment;
 import com.liveklass.testa.domain.klass.domain.Klass;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.liveklass.testa.domain.enrollment.domain.EnrollmentStatus;
-
-import java.util.List;
 
 public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     boolean existsByClassmateAndKlassAndStatusNot(Classmate classmate, Klass klass, EnrollmentStatus status);
 
-    List<Enrollment> findByClassmate(Classmate classmate);
+    Page<Enrollment> findByClassmate(Classmate classmate, Pageable pageable);
 
     int countByKlassAndStatusNot(Klass klass, EnrollmentStatus status);
 
-    List<Enrollment> findByKlassAndStatusNot(Klass klass, EnrollmentStatus status);
+    Page<Enrollment> findByKlassAndStatusNot(Klass klass, EnrollmentStatus status, Pageable pageable);
 }


### PR DESCRIPTION
## Summary

- `GET /enrollments/me`, `GET /classes/{classId}/enrollments` 두 목록 조회 API에 페이지네이션 적용
- Spring Data `Pageable` + `Page` 사용, 기본값: size=20, enrolledAt DESC 정렬
- 쿼리 파라미터: `page`, `size`, `sort` (예: `?page=0&size=5&sort=enrolledAt,asc`)

## 변경 파일

- `EnrollmentRepository`: `List` → `Page` 반환, `Pageable` 파라미터 추가
- `EnrollmentUseCase` / `EnrollmentService`: `Pageable` 파라미터 + `Page<DTO>` 반환
- `EnrollmentController`: `@PageableDefault(size=20, sort="enrolledAt", direction=DESC)` 적용

## Test plan

- [x] `GET /enrollments/me` 기본값 호출 → size=20, enrolledAt DESC 정렬 확인
- [x] `GET /enrollments/me?page=0&size=2` → content 2건, totalPages=4, totalElements=8
- [x] `GET /enrollments/me?page=1&size=2` → 두 번째 페이지, first=false
- [x] `GET /classes/{classId}/enrollments?page=0&size=1` → Creator 전용, 페이지네이션 정상

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)