### PR TITLE
refactor: @Value를 @ConfigurationProperties로 변경

### DIFF
--- a/src/main/java/com/liveklass/testa/TestaApplication.java
+++ b/src/main/java/com/liveklass/testa/TestaApplication.java
@@ -2,8 +2,10 @@ package com.liveklass.testa;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class TestaApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtProperties.java
+++ b/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtProperties.java
@@ -1,0 +1,10 @@
+package com.liveklass.testa.infrastructure.jwt;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+public record JwtProperties(
+        String secret,
+        long expirationMs
+) {
+}

--- a/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/liveklass/testa/infrastructure/jwt/JwtTokenProvider.java
@@ -4,7 +4,6 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -17,11 +16,9 @@ public class JwtTokenProvider {
     private final SecretKey secretKey;
     private final long expirationMs;
 
-    public JwtTokenProvider(
-            @Value("${jwt.secret}") String secret,
-            @Value("${jwt.expiration-ms}") long expirationMs) {
-        this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-        this.expirationMs = expirationMs;
+    public JwtTokenProvider(JwtProperties jwtProperties) {
+        this.secretKey = Keys.hmacShaKeyFor(jwtProperties.secret().getBytes(StandardCharsets.UTF_8));
+        this.expirationMs = jwtProperties.expirationMs();
     }
 
     public String createToken(Long accountId, String email, String role) {


### PR DESCRIPTION
## Summary

- JWT 설정(`jwt.secret`, `jwt.expiration-ms`)을 `@Value` 대신 `@ConfigurationProperties`로 변경
- `JwtProperties` record 추가하여 설정값 그룹화
- `@ConfigurationPropertiesScan` 활성화

## Test plan

- [x] 로그인 → JWT 토큰 발급 정상
- [x] 발급된 토큰으로 인증 필요 API 호출 정상

🤖 Generated with [Claude Code](https://claude.com/claude-code)