### PR TITLE
perf: 목록 조회 N+1 쿼리 해결

### DIFF
--- a/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/application/EnrollmentService.java
@@ -127,7 +127,7 @@ public class EnrollmentService implements EnrollmentUseCase {
         Classmate classmate = classmateRepository.findByAccount(account)
                 .orElseThrow(ClassmateNotFoundException::new);
 
-        return enrollmentRepository.findByClassmate(classmate, pageable)
+        return enrollmentRepository.findByClassmateWithKlass(classmate, pageable)
                 .map(EnrollmentResponse::from);
     }
 
@@ -145,7 +145,7 @@ public class EnrollmentService implements EnrollmentUseCase {
             throw new KlassAccessDeniedException();
         }
 
-        return enrollmentRepository.findByKlassAndStatusNot(klass, EnrollmentStatus.CANCELLED, pageable)
+        return enrollmentRepository.findByKlassAndStatusNotWithClassmate(klass, EnrollmentStatus.CANCELLED, pageable)
                 .map(ClassEnrollmentResponse::from);
     }
 }

--- a/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/enrollment/repository/EnrollmentRepository.java
@@ -8,6 +8,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -15,11 +18,15 @@ public interface EnrollmentRepository extends JpaRepository<Enrollment, Long> {
 
     boolean existsByClassmateAndKlassAndStatusNot(Classmate classmate, Klass klass, EnrollmentStatus status);
 
-    Page<Enrollment> findByClassmate(Classmate classmate, Pageable pageable);
+    @Query(value = "SELECT e FROM Enrollment e JOIN FETCH e.klass WHERE e.classmate = :classmate",
+           countQuery = "SELECT COUNT(e) FROM Enrollment e WHERE e.classmate = :classmate")
+    Page<Enrollment> findByClassmateWithKlass(@Param("classmate") Classmate classmate, Pageable pageable);
 
     int countByKlassAndStatusIn(Klass klass, List<EnrollmentStatus> statuses);
 
-    Page<Enrollment> findByKlassAndStatusNot(Klass klass, EnrollmentStatus status, Pageable pageable);
+    @Query(value = "SELECT e FROM Enrollment e JOIN FETCH e.classmate WHERE e.klass = :klass AND e.status != :status",
+           countQuery = "SELECT COUNT(e) FROM Enrollment e WHERE e.klass = :klass AND e.status != :status")
+    Page<Enrollment> findByKlassAndStatusNotWithClassmate(@Param("klass") Klass klass, @Param("status") EnrollmentStatus status, Pageable pageable);
 
     Optional<Enrollment> findFirstByKlassAndStatusOrderByEnrolledAtAsc(Klass klass, EnrollmentStatus status);
 }

--- a/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/application/KlassService.java
@@ -75,7 +75,7 @@ public class KlassService implements KlassUseCase {
         if (status != null) {
             classes = klassRepository.findByStatus(status);
         } else {
-            classes = klassRepository.findAll();
+            classes = klassRepository.findAllWithCreator();
         }
 
         return classes.stream()
@@ -86,7 +86,7 @@ public class KlassService implements KlassUseCase {
     @Override
     @Transactional(readOnly = true)
     public KlassDetailResponse findById(Long classId) {
-        Klass klass = klassRepository.findById(classId)
+        Klass klass = klassRepository.findByIdWithCreator(classId)
                 .orElseThrow(KlassNotFoundException::new);
 
         int currentEnrollment = enrollmentRepository.countByKlassAndStatusIn(klass,

--- a/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
+++ b/src/main/java/com/liveklass/testa/domain/klass/repository/KlassRepository.java
@@ -13,7 +13,14 @@ import java.util.Optional;
 
 public interface KlassRepository extends JpaRepository<Klass, Long> {
 
-    List<Klass> findByStatus(ClassStatus status);
+    @Query("SELECT k FROM Klass k JOIN FETCH k.creator WHERE k.status = :status")
+    List<Klass> findByStatus(@Param("status") ClassStatus status);
+
+    @Query("SELECT k FROM Klass k JOIN FETCH k.creator")
+    List<Klass> findAllWithCreator();
+
+    @Query("SELECT k FROM Klass k JOIN FETCH k.creator WHERE k.id = :id")
+    Optional<Klass> findByIdWithCreator(@Param("id") Long id);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT k FROM Klass k WHERE k.id = :id")


### PR DESCRIPTION
## Summary

- `KlassRepository`: `findByStatus()`, `findAllWithCreator()`, `findByIdWithCreator()`에 `JOIN FETCH k.creator` 추가
- `EnrollmentRepository`: `findByClassmateWithKlass()`에 `JOIN FETCH e.klass`, `findByKlassAndStatusNotWithClassmate()`에 `JOIN FETCH e.classmate` 추가
- `KlassService`, `EnrollmentService`에서 새 메서드 사용하도록 변경

### 변경 전후 쿼리 수

| 조회 | 변경 전 | 변경 후 |
|------|---------|---------|
| 강의 목록 (N건) | 1 + N | 1 |
| 강의 상세 | 1 + 1 | 1 |
| 내 수강 목록 (N건) | 1 + N | 1 |
| 강의별 수강생 목록 (N건) | 1 + N | 1 |

## Test plan

- [x] 강의 목록 조회 — creatorName 정상 반환
- [x] 강의 상세 조회 — creatorName, currentEnrollment 정상 반환
- [x] 내 수강 목록 — classTitle 정상 반환
- [x] 강의별 수강생 목록 — classmateName 정상 반환

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)
